### PR TITLE
Increase repository discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "homepage": "https://github.com/ThaUnknown/webrtc-polyfill#readme",
+  "bugs": "https://github.com/ThaUnknown/webrtc-polyfill/issues",
+  "repository": "https://github.com/ThaUnknown/webrtc-polyfill.git",
   "dependencies": {
     "node-datachannel": "github:murat-dogan/node-datachannel#polyfill",
     "node-domexception": "^1.0.0"


### PR DESCRIPTION
This PR updates the `package.json` file to add the [bugs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#bugs), [homepage](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#homepage) and [repository](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository) keys to increase discoverability of the GitHub repository from the package at [npmjs.com](https://www.npmjs.com/package/webrtc-polyfill) and address the issue #2.